### PR TITLE
Removed #include <stddef.h> from keyboard.c

### DIFF
--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -1,5 +1,4 @@
 #include "keyboard.h"
-#include <stddef.h>
 
 //TODO: Fix interrupts pls so I can un-bruh this code
 


### PR DESCRIPTION
We write all libs from scratch, so no external includes. Otherwise great code.